### PR TITLE
Small updates to our types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -190,12 +190,12 @@ declare global {
     export interface ImagePaint extends PaintProps {
       type: "image";
       src: string;
-      imageSize: { width: number; height: number };
+      imageSize?: { width: number; height: number };
       scaleMode?: ScaleMode;
       imageTransform?: Transform;
       scalingFactor?: number;
       rotation?: number;
-      imageRef: string;
+      imageRef?: string;
     }
 
     export type Paint = SolidPaint | GradientPaint | ImagePaint;


### PR DESCRIPTION
- Make image size mandatory
- Make ImageRef optional (this is unused)
- Add SyncedMap.size, deprecate SyncedMap.length

Test Plan:
I used `<Image src="..." />` w/o width & height and got this error: 

```
code.tsx:83:8 - error TS2739: Type '{ src: string; }' is missing the following properties from type 'ImageProps': width, height

83       <Image src="https://placekitten.com/200/300"/>
          ~~~~~

[11:06:04 AM] Found 1 error. Watching for file changes.
```

The widget still rendered fine.