### PR TITLE
Fix typings for our JSX IntrinsicAttributes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,18 @@ declare global {
   }
 
   ///////////////////////////////////////////////////////////////////////////////
+  // JSX
+  namespace JSX {
+    /**
+     * You shouldn't need to use this type since you never see these attributes
+     * inside your component or have to validate them.
+     */
+    interface IntrinsicAttributes {
+        key?: string | number | null | undefined;
+    }
+  }
+
+  ///////////////////////////////////////////////////////////////////////////////
   // Widget
 
   interface WidgetAPI {

--- a/test-usage.sh
+++ b/test-usage.sh
@@ -33,6 +33,10 @@ cat > code.tsx << EOF
 const { widget } = figma
 const { AutoLayout, Text, useSyncedState, useSyncedMap, useEffect, usePropertyMenu } = widget
 
+function CustomComponent({ label }: { label: string }) {
+  return <Text>{label}</Text>
+}
+
 function Widget() {
   const [foo, setFoo] = useSyncedState("foo", () => 0)
   const [bar, setBar] = useSyncedState("bar", 0)
@@ -86,6 +90,7 @@ function Widget() {
         {" "}
         {bar}
       </Text>
+      <CustomComponent key={1} label="Hello" />
     </AutoLayout>
   )
 }


### PR DESCRIPTION
Without this, developers have to manually declare `key` in their prop types of custom components when they use the key prop.

See also: https://www.typescriptlang.org/docs/handbook/jsx.html#attribute-type-checking