### PR TITLE
April widget update

### DIFF
--- a/test-usage.sh
+++ b/test-usage.sh
@@ -18,6 +18,7 @@ cat > tsconfig.json << EOF
     "strict": true,
     "jsx": "react",
     "jsxFactory": "figma.widget.h",
+    "jsxFragmentFactory": "figma.widget.Fragment",
     "typeRoots": [
       "./node_modules/@types",
       "./node_modules/@figma"
@@ -31,7 +32,19 @@ cat > code.tsx << EOF
  * Test file to make sure that widget-typings work as expected.
  */
 const { widget } = figma
-const { AutoLayout, Text, useSyncedState, useSyncedMap, useEffect, usePropertyMenu } = widget
+const {
+  AutoLayout,
+  Text,
+  Frame,
+  Ellipse,
+  Line,
+  useSyncedState,
+  useSyncedMap,
+  useEffect,
+  usePropertyMenu,
+  useStickable,
+  useStickableHost,
+} = widget
 
 function CustomComponent({ label }: { label: string }) {
   return <Text>{label}</Text>
@@ -78,6 +91,16 @@ function Widget() {
     ({propertyName, propertyValue}) => {}
   )
 
+  useStickable(async ({newHostId, oldHostId}) => {
+    console.log(newHostId)
+    console.log(oldHostId)
+  })
+
+  useStickableHost(async ({stuckNodeIds, unstuckNodeIds}) => {
+    console.log(stuckNodeIds)
+    console.log(unstuckNodeIds)
+  })
+
   return (
     <AutoLayout>
       <Text
@@ -91,6 +114,18 @@ function Widget() {
         {bar}
       </Text>
       <CustomComponent key={1} label="Hello" />
+      <Frame width={100} height={200}>
+        <Text
+          x={{ type: 'left', offset: 5 }}
+          y={{ type: 'bottom', offset: 5 }}
+        >
+          Offsets
+        </Text>
+        <>
+          <Line />
+          <Ellipse arcData={{ startingAngle: 1, endingAngle: 1, innerRadius: 1}} />
+        </>
+      </Frame>
     </AutoLayout>
   )
 }


### PR DESCRIPTION
This adds all of the typings from the developer preview that are going to be launched this week.
Note, I squashed it all into one commit because it was much easier to prettier it that way.

Here is the list of features added:
- tooltip prop
- Input component
- hoverStyle prop
- Fragment component
- Line vomponent
- Ellipse.arcData prop
- x/y constraints props
- useStickableHost and useStickable
