### PR TITLE
Fix typings for children in custom components

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,8 @@ declare global {
     interface IntrinsicAttributes {
       key?: string | number | null | undefined
     }
+
+    interface ElementChildrenAttribute { children: {}; }
   }
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -173,7 +175,7 @@ declare global {
 
   interface TextProps extends BaseProps, WidgetJSX.TextProps {
     font?: { family: string; style: string }
-    children?: string | string[]
+    children?: string | number | (string|number)[]
   }
 
   interface TextEditEvent {

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,9 @@ declare global {
       key?: string | number | null | undefined
     }
 
-    interface ElementChildrenAttribute { children: {}; }
+    interface ElementChildrenAttribute {
+      children: {}
+    }
   }
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -175,7 +177,7 @@ declare global {
 
   interface TextProps extends BaseProps, WidgetJSX.TextProps {
     font?: { family: string; style: string }
-    children?: string | number | (string|number)[]
+    children?: string | number | (string | number)[]
   }
 
   interface TextEditEvent {

--- a/test-usage.sh
+++ b/test-usage.sh
@@ -50,6 +50,16 @@ function CustomComponent({ label }: { label: string }) {
   return <Text>{label}</Text>
 }
 
+function CustomComponentWithChildren({ children }: {
+  children: FigmaDeclarativeNode | FigmaDeclarativeNode[]
+}) {
+  return (
+    <AutoLayout>
+      {children}
+    </AutoLayout>
+  )
+}
+
 function Widget() {
   const [foo, setFoo] = useSyncedState("foo", () => 0)
   const [bar, setBar] = useSyncedState("bar", 0)
@@ -113,7 +123,9 @@ function Widget() {
         {" "}
         {bar}
       </Text>
-      <CustomComponent key={1} label="Hello" />
+      <CustomComponentWithChildren>
+        <CustomComponent key={1} label="Hello" />
+      </CustomComponentWithChildren>
       <Frame width={100} height={200}>
         <Text
           x={{ type: 'left', offset: 5 }}


### PR DESCRIPTION
Previously you'd get this error if your custom component had children:

```
code.tsx:96:8 - error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { children: FigmaDeclarativeNode | FigmaDeclarativeNode[]; }'.
  Property 'children' is missing in type '{}' but required in type '{ children: FigmaDeclarativeNode | FigmaDeclarativeNode[]; }'.

96       <CustomComponentWithChildren>
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~

  code.tsx:24:3
    24   children: FigmaDeclarativeNode | FigmaDeclarativeNode[]
         ~~~~~~~~
    'children' is declared here.
```