### PR TITLE
Fix key prop to match React

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ declare global {
      * inside your component or have to validate them.
      */
     interface IntrinsicAttributes {
-      key?: string | number | null | undefined
+      key?: string | number | undefined
     }
 
     interface ElementChildrenAttribute {


### PR DESCRIPTION
This matches React types so we don't get a conflict when including both typings:

```
[tsc]  node_modules/@types/react/index.d.ts:2824:19 - error TS2430: Interface 'IntrinsicAttributes' incorrectly extends interface 'Attributes'.
[tsc]    Types of property 'key' are incompatible.
[tsc]      Type 'string | number | null | undefined' is not assignable to type 'Key | undefined'.
[tsc]        Type 'null' is not assignable to type 'Key | undefined'.
[tsc]
[tsc]  2824         interface IntrinsicAttributes extends React.Attributes { }
```