### PR TITLE
Add showShadowBehindNode to effect

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -304,8 +304,19 @@ declare global {
 
     export type Paint = SolidPaint | GradientPaint | ImagePaint
 
-    export interface ShadowEffect {
-      type: 'inner-shadow' | 'drop-shadow'
+    export interface DropShadowEffect {
+      type: 'drop-shadow'
+      color: HexCode | Color
+      offset: Vector
+      blur: number
+      blendMode?: BlendMode
+      spread?: number
+      visible?: boolean
+      showShadowBehindNode?: boolean
+    }
+
+    export interface InnerShadowEffect {
+      type: 'inner-shadow'
       color: HexCode | Color
       offset: Vector
       blur: number
@@ -313,6 +324,8 @@ declare global {
       spread?: number
       visible?: boolean
     }
+
+    export type ShadowEffect = DropShadowEffect | InnerShadowEffect
 
     export interface BlurEffect {
       type: 'layer-blur' | 'background-blur'


### PR DESCRIPTION
A boolean value mapping to 'Show shadow behind transparent areas' in Figma and the plugin prop of the same name
<img width="235" alt="image" src="https://user-images.githubusercontent.com/45389321/165746991-7f154b30-8746-4028-b217-3e31edcc26f0.png">
