### PR TITLE
Add types for Span component

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,6 +61,7 @@ declare global {
     Input: InputComponent
     Line: Line
     Fragment: Fragment
+    Span: Span
   }
 
   interface WidgetStuckEvent {
@@ -107,8 +108,19 @@ declare global {
   type InputComponent = FunctionalWidget<InputProps>
 
   type SVG = FunctionalWidget<SVGProps>
+  type Span = (props: SpanProps) => FigmaVirtualNode<'span'>
 
-  type FigmaDeclarativeNode = Object | any[] | string | null | undefined | false
+  type FigmaVirtualNode<T> = { __type: T }
+
+  type FigmaDeclarativeChildren<T> =
+    | FigmaVirtualNode<T>
+    | FigmaDeclarativeChildren<T>[]
+    | string
+    | null
+    | undefined
+    | false
+
+  type FigmaDeclarativeNode = FigmaDeclarativeChildren<any>
   type FunctionalWidget<T> = (props: T) => FigmaDeclarativeNode
 
   type PropertyMenuItemType = 'action' | 'separator' | 'color-selector' | 'dropdown'
@@ -175,10 +187,19 @@ declare global {
     offsetY: number
   }
 
-  interface TextProps extends BaseProps, WidgetJSX.TextProps {
-    font?: { family: string; style: string }
-    children?: string | number | (string | number)[]
+  interface TextChildren {
+    children?:
+      | FigmaVirtualNode<'span'>
+      | string
+      | number
+      | (FigmaVirtualNode<'span'> | string | number)[]
   }
+
+  interface TextProps extends BaseProps, WidgetJSX.TextProps, TextChildren {
+    font?: { family: string; style: string }
+  }
+
+  interface SpanProps extends WidgetJSX.SpanProps, TextChildren {}
 
   interface TextEditEvent {
     characters: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@figma/widget-typings",
-  "version": "1.0.4",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@figma/widget-typings",
-      "version": "1.0.4",
+      "version": "1.4.0",
       "license": "MIT License",
       "devDependencies": {
         "prettier": "^2.6.2"

--- a/test-usage.sh
+++ b/test-usage.sh
@@ -40,6 +40,7 @@ const {
   Ellipse,
   Line,
   Rectangle,
+  Span,
   useSyncedState,
   useSyncedMap,
   useEffect,
@@ -125,6 +126,7 @@ function Widget() {
         {foo}
         {" "}
         {bar}
+        <Span>Hello <Span>World</Span></Span>
       </Text>
       <CustomComponentWithChildren>
         <CustomComponent key={1} label="Hello" />


### PR DESCRIPTION
This adds the Span component to our typings. It was actually already in there for a while so I just needed to export the typings. Sadly I learned that there is no way to safely type the children of a React component in typescript since they always return JSX.Element and there is no way to refine what element a component returns. I did add some typing so at least as a reader you can see that text can only take strings, numbers, and spans, but it isn't actually enforced. You can see [this issue](https://github.com/microsoft/TypeScript/issues/21699) for more information on this. Surprisingly this is the first time when I actually actively prefer Flow, which makes it [rather easy to do this ](https://flow.org/en/docs/react/children/#toc-only-allowing-a-specific-element-type-as-children).