### PR TITLE
Added types for link menu item

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -123,7 +123,7 @@ declare global {
   type FigmaDeclarativeNode = FigmaDeclarativeChildren<any>
   type FunctionalWidget<T> = (props: T) => FigmaDeclarativeNode
 
-  type PropertyMenuItemType = 'action' | 'separator' | 'color-selector' | 'dropdown'
+  type PropertyMenuItemType = 'action' | 'separator' | 'color-selector' | 'dropdown' | 'link'
 
   type HexCode = string
   interface PropertyMenuItem {
@@ -136,7 +136,11 @@ declare global {
     itemType: 'action'
     icon?: string
   }
-
+  interface WidgetPropertyMenuLinkItem extends PropertyMenuItem {
+    itemType: 'link'
+    icon?: string
+    href: string
+  }
   interface WidgetPropertyMenuSeparatorItem {
     itemType: 'separator'
   }
@@ -168,6 +172,7 @@ declare global {
     | WidgetPropertyMenuSeparatorItem
     | WidgetPropertyMenuColorItem
     | WidgetPropertyMenuDropdownItem
+    | WidgetPropertyMenuLinkItem
 
   type WidgetPropertyMenu = WidgetPropertyMenuItem[]
   type WidgetPropertyEvent = {

--- a/test-usage.sh
+++ b/test-usage.sh
@@ -101,6 +101,12 @@ function Widget() {
         selectedOption: 'option1',
         options: [{option: 'option1', label: 'Option 1'}],
       },
+      {
+        itemType: 'link',
+        propertyName: 'link',
+        tooltip: 'link',
+        href: 'www.google.com',
+      },
     ],
     ({propertyName, propertyValue}) => {}
   )


### PR DESCRIPTION
Adds the `link` menu item type. The functionality is implemented [here](https://github.com/figma/figma/pull/71343) and the documentation is implemented [here](https://github.com/figma/figma/pull/71537).