### PR TITLE
Made icon nullable for link menu items

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -144,7 +144,7 @@ declare global {
   }
   interface WidgetPropertyMenuLinkItem extends PropertyMenuItem {
     itemType: 'link'
-    icon?: string
+    icon?: string | null
     href: string
   }
   interface WidgetPropertyMenuSeparatorItem {

--- a/test-usage.sh
+++ b/test-usage.sh
@@ -113,6 +113,13 @@ function Widget() {
         tooltip: 'link',
         href: 'www.google.com',
       },
+      {
+        tooltip: 'link with icon null',
+        propertyName: 'Link',
+        itemType: 'link',
+        href: 'https://asana.com',
+        icon: null,
+      },
     ],
     ({propertyName, propertyValue}) => {}
   )


### PR DESCRIPTION
Added ability to make `icon` null for link menu items. This allows users to override the default icon with text.