### PR TITLE
index.d.ts: remove version string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-// Figma Widget API version 1, update 1
 /// <reference path="./widget-api.d.ts"/>
 declare global {
   // Extend the global widget api


### PR DESCRIPTION
The version comment in `index.d.ts` is out-of-date and worse than nothing, so let's just chuck it!