### PR TITLE
misc changes, no publication required

### DIFF
--- a/widget-api-standalone.d.ts
+++ b/widget-api-standalone.d.ts
@@ -1,4 +1,8 @@
-/* widget-typings are auto-generated. Do not update them directly. See widget-docs/ for instructions. */
+/* widget-typings are auto-generated. Do not update them directly. See plugin-docs/ for instructions. */
+/**
+ * NOTE: This file is useful if you want to import specific types eg.
+ * import type { WidgetJSXFrameProps } from "@figma/widget-typings/widget-api-standalone"
+ */
 interface WidgetAPI {
   register(component: FunctionalWidget<any>): void
   h(...args: any[]): FigmaDeclarativeNode
@@ -531,3 +535,6 @@ declare namespace WidgetJSX {
   }
   type ComponentProps = AutoLayoutProps | FrameProps
 }
+
+// prettier-ignore
+export { WidgetAPI, WidgetClickEvent, WidgetStuckEvent, WidgetAttachedStickablesChangedEvent, SyncedMap, AutoLayout, Frame, Rectangle, ImageComponent, Ellipse, Line, TextComponent, Input, SVG, Fragment, Span, FigmaVirtualNode, FigmaDeclarativeChildren, FigmaDeclarativeNode, FunctionalWidget, PropertyMenuItemType, PropertyMenuItem, WidgetPropertyMenuActionItem, WidgetPropertyMenuSeparatorItem, WidgetPropertyMenuColorSelectorOption, WidgetPropertyMenuColorItem, WidgetPropertyMenuDropdownOption, WidgetPropertyMenuDropdownItem, WidgetPropertyMenuToggleItem, WidgetPropertyMenuLinkItem, WidgetPropertyMenuItem, WidgetPropertyMenu, WidgetPropertyEvent, TextChildren, TextProps, TextEditEvent, PlaceholderProps, InputProps, FragmentProps, FrameProps, AutoLayoutProps, EllipseProps, RectangleProps, ImageProps, LineProps, SVGProps, BaseProps, HasChildrenProps, HexCode, WidgetJSX }


### PR DESCRIPTION
This change adds a file and a comment tweak, just so we don't keep seeing these diffs when we push changes from our internal repo to the external one. It's not 100% clear to me whether this is necessary for widgets, but we might as well keep it consistent with plugin-docs.